### PR TITLE
Updated Regex to match new format

### DIFF
--- a/letour.go
+++ b/letour.go
@@ -56,7 +56,7 @@ type Entry struct {
 }
 
 func (e *Entry) IsHighlight() bool {
-	match, _ := regexp.MatchString("(?i)tour de france.+(stage \\d+|prologue).+highlights", e.Title)
+	match, _ := regexp.MatchString("(?i)tour de france.+(stage \\d+|prologue|highlights).+(highlights|stage \\d+)", e.Title)
 	return match
 }
 


### PR DESCRIPTION
The format for the highlights package was different for stage 5.  I _think_ this new regex handles it, but haven't tested it.  I also don't know golang, so there might be a better way of handling the difference.  This was more meant to point out the change rather than be the actual fix.
