### PR TITLE
2016 tour

### DIFF
--- a/cli/letour.go
+++ b/cli/letour.go
@@ -1,56 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"regexp"
+
+	"github.com/joho/letour/sbs"
 )
 
-type MediaItemFeed []MediaItem
-
-type MediaItem struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	ProgramName string `json:"programName"`
-}
-
 func main() {
-	// curl http://www.sbs.com.au/cyclingcentral/?cid=infocus
-	// SBS.mpxWidget.setVideos
-
-	// generate urls like:
-	//		http://www.sbs.com.au/ondemand/video/single/713877571952/?source=drupal&vertical=cyclingcentral
-	res, err := http.Get("http://www.sbs.com.au/cyclingcentral/?cid=infocus")
-	if err != nil {
-		panic(err)
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	r := regexp.MustCompile(`SBS.mpxWidget.setVideos\(mpxBeanId, (\[.+\]), \d.+;`)
-	subMatches := r.FindSubmatch(body)
-	if len(subMatches) != 2 {
-		panic("didn't find the mega json array")
-	}
-
-	// fmt.Println(string(subMatches[1]))
-
-	var feed MediaItemFeed
-	err = json.Unmarshal(subMatches[1], &feed)
-	if err != nil {
-		panic(err)
-	}
-
-	for _, mediaItem := range feed {
-		if mediaItem.ProgramName == "Tour De France: Highlights" {
-			fmt.Printf("%v\n", mediaItem.Title)
-			fmt.Printf("http://www.sbs.com.au/ondemand/video/single/%v/?source=drupal&vertical=cyclingcentral\n", mediaItem.ID)
-		}
+	feed := sbs.GetHighlights()
+	for _, v := range feed {
+		fmt.Printf("%v\n%v\n", v.Title, v.Url())
 	}
 }

--- a/cli/letour.go
+++ b/cli/letour.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 )
+
+type MediaItemFeed []MediaItem
+
+type MediaItem struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	ProgramName string `json:"programName"`
+}
 
 func main() {
 	// curl http://www.sbs.com.au/cyclingcentral/?cid=infocus
@@ -23,16 +33,24 @@ func main() {
 		panic(err)
 	}
 
-	//  SBS.mpxWidget.setVideos(mpxBeanId, [{"id":"723969091538","idUrl":"http:\/\/data.media.theplatform.com\/media\/data\/Media\/723969091538","defaultThumbnail":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/13\/723969091538_07131207_image124125_large.jpg","pubDate":1468371600000,"availableDate":1468371600000,"expirationDate":1499734920000,"description":"Share the spirit of the Tour with OFX","title":"Share the spirit of the Tour with OFX","programName":"","content":[{"plfile$bitrate":128000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_128K.mp4"},{"plfile$bitrate":1000000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_1000K.mp4"},{"plfile$bitrate":512000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_300K.mp4"},{"plfile$bitrate":1500000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_1500K.mp4"}],"categories":[{"media$name":"Sport","media$scheme":"Genre","media$label":""},{"media$name":"Sport\/Cycling","media$scheme":"","media$label":""},{"media$name":"Section","media$scheme":"Section","media$label":""},{"media$name":"Section\/Clips","media$scheme":
-	//
-	// SNIP
-	//
-	// http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/11\/722350147591_07110707_image074057_facebook.jpg","Thumbnail Carousel Small":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/11\/722350147591_07110707_image074057_carouselsmall.jpg"},"episodeNumbermpx":"","keywords":["Tour de France 2016 Stage 8","Stage8","Tour de France 2016"],"language":"English","useType":"Interview","tx":"Monday 11 July 7:23am"}], 1, '/cyclingcentral/profiles/sbsdistribution/themes/global/images/on-demand-carousel/no-image.jpg', isPromo, 'http://www.sbs.com.au/api/video_feed/f/Bgtm9B/sbs-search?form=json&range=1-20&byCategories=Sport%2FCycling');
-
 	r := regexp.MustCompile(`SBS.mpxWidget.setVideos\(mpxBeanId, (\[.+\]), \d.+;`)
 	subMatches := r.FindSubmatch(body)
 	if len(subMatches) != 2 {
 		panic("didn't find the mega json array")
 	}
-	fmt.Printf("%v", string(subMatches[1]))
+
+	// fmt.Println(string(subMatches[1]))
+
+	var feed MediaItemFeed
+	err = json.Unmarshal(subMatches[1], &feed)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, mediaItem := range feed {
+		if mediaItem.ProgramName == "Tour De France: Highlights" {
+			fmt.Printf("%v\n", mediaItem.Title)
+			fmt.Printf("http://www.sbs.com.au/ondemand/video/single/%v/?source=drupal&vertical=cyclingcentral\n", mediaItem.ID)
+		}
+	}
 }

--- a/cli/letour.go
+++ b/cli/letour.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+)
+
+func main() {
+	// curl http://www.sbs.com.au/cyclingcentral/?cid=infocus
+	// SBS.mpxWidget.setVideos
+
+	// generate urls like:
+	//		http://www.sbs.com.au/ondemand/video/single/713877571952/?source=drupal&vertical=cyclingcentral
+	res, err := http.Get("http://www.sbs.com.au/cyclingcentral/?cid=infocus")
+	if err != nil {
+		panic(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	//  SBS.mpxWidget.setVideos(mpxBeanId, [{"id":"723969091538","idUrl":"http:\/\/data.media.theplatform.com\/media\/data\/Media\/723969091538","defaultThumbnail":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/13\/723969091538_07131207_image124125_large.jpg","pubDate":1468371600000,"availableDate":1468371600000,"expirationDate":1499734920000,"description":"Share the spirit of the Tour with OFX","title":"Share the spirit of the Tour with OFX","programName":"","content":[{"plfile$bitrate":128000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_128K.mp4"},{"plfile$bitrate":1000000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_1000K.mp4"},{"plfile$bitrate":512000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_300K.mp4"},{"plfile$bitrate":1500000,"plfile$contentType":"video","plfile$duration":63,"plfile$format":"MPEG4","plfile$height":0,"plfile$width":0,"plfile$assetTypes":["Public"],"plfile$downloadUrl":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS_Production\/managed\/2016\/07\/13\/723969091538_1500K.mp4"}],"categories":[{"media$name":"Sport","media$scheme":"Genre","media$label":""},{"media$name":"Sport\/Cycling","media$scheme":"","media$label":""},{"media$name":"Section","media$scheme":"Section","media$label":""},{"media$name":"Section\/Clips","media$scheme":
+	//
+	// SNIP
+	//
+	// http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/11\/722350147591_07110707_image074057_facebook.jpg","Thumbnail Carousel Small":"http:\/\/videocdn.sbs.com.au\/u\/video\/SBS\/managed\/images\/2016\/07\/11\/722350147591_07110707_image074057_carouselsmall.jpg"},"episodeNumbermpx":"","keywords":["Tour de France 2016 Stage 8","Stage8","Tour de France 2016"],"language":"English","useType":"Interview","tx":"Monday 11 July 7:23am"}], 1, '/cyclingcentral/profiles/sbsdistribution/themes/global/images/on-demand-carousel/no-image.jpg', isPromo, 'http://www.sbs.com.au/api/video_feed/f/Bgtm9B/sbs-search?form=json&range=1-20&byCategories=Sport%2FCycling');
+
+	r := regexp.MustCompile(`SBS.mpxWidget.setVideos\(mpxBeanId, (\[.+\]), \d.+;`)
+	subMatches := r.FindSubmatch(body)
+	if len(subMatches) != 2 {
+		panic("didn't find the mega json array")
+	}
+	fmt.Printf("%v", string(subMatches[1]))
+}

--- a/letour.go
+++ b/letour.go
@@ -26,7 +26,7 @@ func serveWebsite() {
 	appHandler := prohttphandler.New("public")
 
 	appHandler.ExactMatchFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		links := sbs.GetLinks()
+		links := sbs.GetHighlights()
 		t, err := template.ParseFiles("views/index.tmpl.html")
 		if err == nil {
 			t.Execute(w, links)

--- a/views/index.tmpl.html
+++ b/views/index.tmpl.html
@@ -32,13 +32,9 @@
       <ul>
         {{range .}}
           <li>
-            {{ if .VideoUrl }}
-              <a href="{{ .VideoUrl }}" title="{{ .Title }}">
-                {{ .Title }}
-              </a>
-            {{ else }}
-              {{ .Title }} (no mp4 found)
-            {{ end }}
+            <a href="{{ .Url }}" title="{{ .Title }}">
+              {{ .Title }}
+            </a>
           </li>
         {{ end }}
       </ul>


### PR DESCRIPTION
Update the site to work with the 2016 version of SBS' website.

No longer deep links into mp4 files directly but instead sends you to what would ordinarily be an iframe'd in SBS ondemand viewer. This means you will see ads like on the normal site, but at least you're still free of spoilers.

This is likely to be incredibly fragile.