### PR TITLE
2017 tour url update

### DIFF
--- a/letour.go
+++ b/letour.go
@@ -37,10 +37,10 @@ func serveWebsite() {
 
 	var handler http.Handler = appHandler
 
-	bugsnagApiKey := os.Getenv("BUGSNAG_API_KEY")
-	if bugsnagApiKey != "" {
+	bugsnagAPIKey := os.Getenv("BUGSNAG_API_KEY")
+	if bugsnagAPIKey != "" {
 		bugsnag.Configure(bugsnag.Configuration{
-			APIKey: bugsnagApiKey,
+			APIKey: bugsnagAPIKey,
 		})
 		handler = bugsnag.Handler(appHandler)
 	}

--- a/sbs/sbs.go
+++ b/sbs/sbs.go
@@ -51,8 +51,9 @@ func GetHighlights() MediaItemFeed {
 
 	highlightsFeed := MediaItemFeed{}
 
+	titleRegexp := regexp.MustCompile(`(?i)tdf 2017 stage \d+ highlights`)
 	for _, mediaItem := range feed {
-		if mediaItem.ProgramName == "Tour De France: Highlights" {
+		if titleRegexp.MatchString(mediaItem.Title) {
 			highlightsFeed = append(highlightsFeed, mediaItem)
 		}
 	}


### PR DESCRIPTION
Fixed the matching on the video feeds to pull out the right URLs for the 2017 tour.